### PR TITLE
fix: gracefully handle failure to find paraview root

### DIFF
--- a/ptc/utils.py
+++ b/ptc/utils.py
@@ -5,14 +5,23 @@ import paraview
 
 def find_paraview_root_directory():
     current = Path(paraview.__file__).resolve().parent.parent
+    root_path = Path('/').resolve()  # This works on all operating systems
     while "paraview" not in current.name.lower():
         current = current.parent
+        if current == root_path:
+            # Failed to find it. Exit early.
+            return None
+
     return current
 
 
 def find_paraview_examples_directory(root_path):
+    if root_path is None:
+        return None
+
     for found_file in root_path.glob("**/can.ex2"):
         return found_file.parent
+
     return None
 
 


### PR DESCRIPTION
Previously, if the paraview root was not found, this function would end up in an infinite loop, since the parent of the root directory is also the root directory. This was happening for conda installations, in particular. If the root is not found, gracefully set the paths to `None`.