### PR TITLE
Add reset camera buttons

### DIFF
--- a/examples/reset-camera-example.py
+++ b/examples/reset-camera-example.py
@@ -73,11 +73,11 @@ class ConeApp:
 
                 # Choose which buttons to show
                 # ResetCameraButtons(
-                #     reset_camera_visibility=True,
-                #     reset_camera_x_visibility=False,
-                #     reset_camera_y_visibility=False,
-                #     reset_camera_z_visibility=True,
-                #     interaction_mode_visibility=True, # Toggle between 2D and 3D
+                #     show_reset_camera=True,
+                #     show_reset_camera_x=False,
+                #     show_reset_camera_y=False,
+                #     show_reset_camera_z=True,
+                #     show_interaction_mode=True, # Toggle between 2D and 3D
                 # )
                 # ResetCameraButtons(classes="position-absolute", style="top: 1rem; right: 1rem;")
                 self.ctrl.view_reset_camera = html_view.reset_camera

--- a/examples/reset-camera-example.py
+++ b/examples/reset-camera-example.py
@@ -6,7 +6,7 @@ with the inclusion of the buttons
 import paraview.web.venv  # noqa: F401, isort: skip
 
 
-from trame.app import get_server, TrameApp
+from trame.app import TrameApp
 from trame.decorators import change
 from trame.widgets import vuetify3 as v3, paraview as pv_widgets
 from trame.ui.vuetify3 import SinglePageLayout

--- a/examples/reset-camera-example.py
+++ b/examples/reset-camera-example.py
@@ -6,8 +6,8 @@ with the inclusion of the buttons
 import paraview.web.venv  # noqa: F401, isort: skip
 
 
-from trame.app import get_server
-from trame.decorators import TrameApp, change
+from trame.app import get_server, TrameApp
+from trame.decorators import change
 from trame.widgets import vuetify3 as v3, paraview as pv_widgets
 from trame.ui.vuetify3 import SinglePageLayout
 
@@ -18,7 +18,7 @@ from ptc import ResetCameraButtons
 
 class ConeApp(TrameApp):
     def __init__(self, server=None):
-        self.server = get_server(server, client_type="vue3")
+        super().__init__(server, client_type="vue3")
 
         self.cone = simple.Cone()
         self.representation = simple.Show(self.cone)
@@ -26,14 +26,6 @@ class ConeApp(TrameApp):
 
         self.state.trame__title = "ParaView - Cone"
         self.ui = self._build_ui()
-
-    @property
-    def state(self):
-        return self.server.state
-
-    @property
-    def ctrl(self):
-        return self.server.controller
 
     @change("resolution")
     def on_resolution_change(self, resolution, **_):

--- a/examples/reset-camera-example.py
+++ b/examples/reset-camera-example.py
@@ -70,12 +70,14 @@ class ConeApp:
                 pv_widgets.VtkRemoteView(self.view, interactive_ratio=1) as html_view,
             ):
                 ResetCameraButtons(rounded="xl")
+
+                # Choose which buttons to show
                 # ResetCameraButtons(
-                #     reset_camera=True,
-                #     reset_camera_x=False,
-                #     reset_camera_y=False,
-                #     reset_camera_z=True,
-                #     camera_style_toggle=True, # Toggle between 2D and 3D
+                #     reset_camera_visibility=True,
+                #     reset_camera_x_visibility=False,
+                #     reset_camera_y_visibility=False,
+                #     reset_camera_z_visibility=True,
+                #     interaction_mode_visibility=True, # Toggle between 2D and 3D
                 # )
                 # ResetCameraButtons(classes="position-absolute", style="top: 1rem; right: 1rem;")
                 self.ctrl.view_reset_camera = html_view.reset_camera

--- a/examples/reset-camera-example.py
+++ b/examples/reset-camera-example.py
@@ -16,8 +16,7 @@ from ptc import ResetCameraButtons
 # -----------------------------------------------------------------------------
 
 
-@TrameApp()
-class ConeApp:
+class ConeApp(TrameApp):
     def __init__(self, server=None):
         self.server = get_server(server, client_type="vue3")
 

--- a/examples/reset-camera-example.py
+++ b/examples/reset-camera-example.py
@@ -70,6 +70,13 @@ class ConeApp:
                 pv_widgets.VtkRemoteView(self.view, interactive_ratio=1) as html_view,
             ):
                 ResetCameraButtons(rounded="xl")
+                # ResetCameraButtons(
+                #     reset_camera=True,
+                #     reset_camera_x=False,
+                #     reset_camera_y=False,
+                #     reset_camera_z=True,
+                #     camera_style_toggle=True, # Toggle between 2D and 3D
+                # )
                 # ResetCameraButtons(classes="position-absolute", style="top: 1rem; right: 1rem;")
                 self.ctrl.view_reset_camera = html_view.reset_camera
                 self.ctrl.view_update = html_view.update

--- a/examples/reset-camera-example.py
+++ b/examples/reset-camera-example.py
@@ -1,0 +1,84 @@
+"""
+This example is taken from the classroom tutorial of https://docs.paraview.org/en/latest/Tutorials/ClassroomTutorials/targetedTrame.html
+with the inclusion of the buttons
+"""
+
+import paraview.web.venv  # noqa: F401, isort: skip
+
+
+from trame.app import get_server
+from trame.decorators import TrameApp, change
+from trame.widgets import vuetify3 as v3, paraview as pv_widgets
+from trame.ui.vuetify3 import SinglePageLayout
+
+from paraview import simple
+from ptc import ResetCameraButtons
+# -----------------------------------------------------------------------------
+
+
+@TrameApp()
+class ConeApp:
+    def __init__(self, server=None):
+        self.server = get_server(server, client_type="vue3")
+
+        self.cone = simple.Cone()
+        self.representation = simple.Show(self.cone)
+        self.view = simple.Render()
+
+        self.state.trame__title = "ParaView - Cone"
+        self.ui = self._build_ui()
+
+    @property
+    def state(self):
+        return self.server.state
+
+    @property
+    def ctrl(self):
+        return self.server.controller
+
+    @change("resolution")
+    def on_resolution_change(self, resolution, **_):
+        self.cone.Resolution = resolution
+        self.ctrl.view_update()
+
+    def reset_resolution(self):
+        self.state.resolution = 6
+
+    def _build_ui(self):
+        with SinglePageLayout(self.server, full_height=True) as layout:
+            layout.icon.click = self.ctrl.view_reset_camera
+            layout.title.set_text("ParaView - Cone")
+
+            with layout.toolbar:
+                v3.VSpacer()
+                v3.VSlider(
+                    v_model=("resolution", 6),
+                    min=3,
+                    max=60,
+                    step=1,
+                    hide_details=True,
+                    dense=True,
+                    style="max-width: 300px",
+                )
+                v3.VDivider(vertical=True, classes="mx-2")
+                with v3.VBtn(icon=True, click=self.reset_resolution):
+                    v3.VIcon("mdi-undo-variant")
+
+            with (
+                layout.content,
+                v3.VContainer(fluid=True, classes="pa-0 fill-height"),
+                pv_widgets.VtkRemoteView(self.view, interactive_ratio=1) as html_view,
+            ):
+                ResetCameraButtons(rounded="xl")
+                # ResetCameraButtons(classes="position-absolute", style="top: 1rem; right: 1rem;")
+                self.ctrl.view_reset_camera = html_view.reset_camera
+                self.ctrl.view_update = html_view.update
+
+            return layout
+
+
+# -----------------------------------------------------------------------------
+
+
+app = ConeApp()
+app.server.start()

--- a/ptc/__init__.py
+++ b/ptc/__init__.py
@@ -6,6 +6,7 @@ from .hover import HoverPoint  # noqa: F401
 from .palette import PalettePicker  # noqa: F401
 from .pipeline import PipelineBrowser  # noqa: F401
 from .representation import RepresentBy  # noqa: F401
+from .reset_camera_button import ResetCameraButtons  # noqa: F401
 from .utils import PARAVIEW_EXAMPLES, PARAVIEW_ROOT  # noqa: F401
 from .vcr import TimeControl  # noqa: F401
 from .views.table import ViewTable  # noqa: F401

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -34,10 +34,6 @@ class ResetCameraButtons(v3.VBtnGroup):
         )
 
         self.state.setdefault("interaction_mode", "3D")
-        self.state.setdefault("show_reset_camera", show_reset_camera)
-        self.state.setdefault("show_reset_camera_x", show_reset_camera_x)
-        self.state.setdefault("show_reset_camera_y", show_reset_camera_y)
-        self.state.setdefault("show_reset_camera_z", show_reset_camera_z)
         self.state.setdefault("show_interaction_mode", show_interaction_mode)
 
         def reset_camera_callback() -> None:
@@ -70,7 +66,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                     v_bind=("props",),
                     click=(change_interaction_mode, "['3D']"),
                     v_show=("interaction_mode === '2D'"),
-                    v_if=("show_interaction_mode",),
+                    v_if=("show_interaction_mode", show_interaction_mode),
                 )
 
             with (
@@ -97,7 +93,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-crop-free",
                         v_bind=("props",),
                         click=reset_camera_callback,
-                        v_if=("show_reset_camera",),
+                        v_if=("show_reset_camera", show_reset_camera),
                     ),
                 )
 
@@ -113,7 +109,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-axis-x-arrow",
                         v_bind=("props",),
                         click=reset_to_positive_x,
-                        v_if=("show_reset_camera_x",),
+                        v_if=("show_reset_camera_x", show_reset_camera_x),
                     ),
                 )
 
@@ -129,7 +125,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-axis-y-arrow",
                         v_bind=("props",),
                         click=reset_to_positive_y,
-                        v_if=("show_reset_camera_y",),
+                        v_if=("show_reset_camera_y", show_reset_camera_y),
                     ),
                 )
 
@@ -145,7 +141,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-axis-z-arrow",
                         v_bind=("props",),
                         click=reset_to_positive_z,
-                        v_if=("show_reset_camera_z",),
+                        v_if=("show_reset_camera_z", show_reset_camera_z),
                     ),
                 )
 

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -1,21 +1,6 @@
-from dataclasses import dataclass
-from typing import Callable
-
+from typing import Literal
 from paraview import simple
 from trame.widgets import vuetify3 as v3
-
-
-@dataclass
-class Button:
-    """
-    A minimal class to create a button.
-    """
-
-    icon: str
-    tooltip: str
-    click_callback: Callable
-    v_show: str = "true"
-    v_if: str = "true"
 
 
 class ResetCameraButtons(v3.VBtnGroup):
@@ -72,78 +57,99 @@ class ResetCameraButtons(v3.VBtnGroup):
             self.view.ResetActiveCameraToPositiveZ()
             self.ctrl.view_reset_camera()
 
-        def toggle_interaction_mode_2D() -> None:
-            self.view.InteractionMode = "2D"
-            self.state.interaction_mode = "2D"
-
-        def toggle_interaction_mode_3D() -> None:
-            self.view.InteractionMode = "3D"
-            self.state.interaction_mode = "3D"
-
-        buttons = [
-            Button(
-                icon="mdi-video-2d",
-                tooltip="Change interaction mode",
-                click_callback=toggle_interaction_mode_3D,
-                v_show=("interaction_mode === '2D'"),
-                v_if=("interaction_mode_visibility",),
-            ),
-            Button(
-                icon="mdi-video-3d",
-                tooltip="Change interaction mode",
-                click_callback=toggle_interaction_mode_2D,
-                v_show=("interaction_mode === '3D'"),
-                v_if=("interaction_mode_visibility",),
-            ),
-            Button(
-                icon="mdi-crop-free",
-                tooltip="Reset Camera",
-                click_callback=reset_camera_callback,
-                v_if=("reset_camera_visibility",),
-            ),
-            Button(
-                icon="mdi-axis-x-arrow",
-                tooltip="Set view direction to +X",
-                click_callback=reset_to_positive_x,
-                v_if=("reset_camera_x_visibility",),
-            ),
-            Button(
-                icon="mdi-axis-y-arrow",
-                tooltip="Set view direction to +Y",
-                click_callback=reset_to_positive_y,
-                v_if=("reset_camera_y_visibility",),
-            ),
-            Button(
-                icon="mdi-axis-z-arrow",
-                tooltip="Set view direction to +Z",
-                click_callback=reset_to_positive_z,
-                v_if=("reset_camera_z_visibility",),
-            ),
-        ]
+        def change_interaction_mode(mode: Literal["2D", "3D"]) -> None:
+            self.view.InteractionMode = mode
+            self.state.interaction_mode = mode
+            self.ctrl.view_update()
 
         with self:
-            for button in buttons:
-                if button.tooltip is None:
+            with (
+                v3.VTooltip("Change interaction mode", location="bottom"),
+                v3.Template(v_slot_activator=("{ props }",)),
+            ):
+                v3.VBtn(
+                    icon="mdi-video-2d",
+                    v_bind=("props",),
+                    click=(change_interaction_mode, "['3D']"),
+                    v_show=("interaction_mode === '2D'"),
+                    v_if=("interaction_mode_visibility",),
+                )
+
+            with (
+                v3.VTooltip("Change interaction mode", location="bottom"),
+                v3.Template(v_slot_activator=("{ props }",)),
+            ):
+                v3.VBtn(
+                    icon="mdi-video-3d",
+                    v_bind=("props",),
+                    click=(change_interaction_mode, "['2D']"),
+                    v_show=("interaction_mode === '3D'"),
+                    v_if=("interaction_mode_visibility",),
+                )
+
+            with (
+                v3.VTooltip(
+                    "Reset Camera",
+                    location="bottom",
+                ),
+                v3.Template(v_slot_activator=("{ props }",)),
+            ):
+                (
                     v3.VBtn(
-                        icon=button.icon,
-                        click=button.click_callback,
-                        size="small",
-                        v_show=button.v_show,
-                        v_if=button.v_if,
-                    )
-                else:
-                    with (
-                        v3.VTooltip(button.tooltip, location="bottom"),
-                        v3.Template(v_slot_activator=("{ props }",)),
-                    ):
-                        v3.VBtn(
-                            icon=button.icon,
-                            v_bind=("props",),
-                            click=button.click_callback,
-                            size="small",
-                            v_show=button.v_show,
-                            v_if=button.v_if,
-                        )
+                        icon="mdi-crop-free",
+                        v_bind=("props",),
+                        click=reset_camera_callback,
+                        v_if=("reset_camera_visibility",),
+                    ),
+                )
+
+            with (
+                v3.VTooltip(
+                    "Set view direction to +X",
+                    location="bottom",
+                ),
+                v3.Template(v_slot_activator=("{ props }",)),
+            ):
+                (
+                    v3.VBtn(
+                        icon="mdi-axis-x-arrow",
+                        v_bind=("props",),
+                        click=reset_to_positive_x,
+                        v_if=("reset_camera_x_visibility",),
+                    ),
+                )
+
+            with (
+                v3.VTooltip(
+                    "Set view direction to +Y",
+                    location="bottom",
+                ),
+                v3.Template(v_slot_activator=("{ props }",)),
+            ):
+                (
+                    v3.VBtn(
+                        icon="mdi-axis-y-arrow",
+                        v_bind=("props",),
+                        click=reset_to_positive_y,
+                        v_if=("reset_camera_y_visibility",),
+                    ),
+                )
+
+            with (
+                v3.VTooltip(
+                    "Set view direction to +Z",
+                    location="bottom",
+                ),
+                v3.Template(v_slot_activator=("{ props }",)),
+            ):
+                (
+                    v3.VBtn(
+                        icon="mdi-axis-z-arrow",
+                        v_bind=("props",),
+                        click=reset_to_positive_z,
+                        v_if=("reset_camera_z_visibility",),
+                    ),
+                )
 
     @property
     def view(self):

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -16,11 +16,11 @@ class ResetCameraButtons(v3.VBtnGroup):
         self,
         style: str | None = None,
         classes: str | None = None,
-        reset_camera_visibility: bool = True,
-        reset_camera_x_visibility: bool = True,
-        reset_camera_y_visibility: bool = True,
-        reset_camera_z_visibility: bool = True,
-        interaction_mode_visibility: bool = True,
+        show_reset_camera: bool = True,
+        show_reset_camera_x: bool = True,
+        show_reset_camera_y: bool = True,
+        show_reset_camera_z: bool = True,
+        show_interaction_mode: bool = True,
         **kwargs,
     ) -> None:
         if style is None:
@@ -34,13 +34,11 @@ class ResetCameraButtons(v3.VBtnGroup):
         )
 
         self.state.setdefault("interaction_mode", "3D")
-        self.state.setdefault("reset_camera_visibility", reset_camera_visibility)
-        self.state.setdefault("reset_camera_x_visibility", reset_camera_x_visibility)
-        self.state.setdefault("reset_camera_y_visibility", reset_camera_y_visibility)
-        self.state.setdefault("reset_camera_z_visibility", reset_camera_z_visibility)
-        self.state.setdefault(
-            "interaction_mode_visibility", interaction_mode_visibility
-        )
+        self.state.setdefault("show_reset_camera", show_reset_camera)
+        self.state.setdefault("show_reset_camera_x", show_reset_camera_x)
+        self.state.setdefault("show_reset_camera_y", show_reset_camera_y)
+        self.state.setdefault("show_reset_camera_z", show_reset_camera_z)
+        self.state.setdefault("show_interaction_mode", show_interaction_mode)
 
         def reset_camera_callback() -> None:
             self.ctrl.view_reset_camera()
@@ -72,7 +70,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                     v_bind=("props",),
                     click=(change_interaction_mode, "['3D']"),
                     v_show=("interaction_mode === '2D'"),
-                    v_if=("interaction_mode_visibility",),
+                    v_if=("show_interaction_mode",),
                 )
 
             with (
@@ -84,7 +82,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                     v_bind=("props",),
                     click=(change_interaction_mode, "['2D']"),
                     v_show=("interaction_mode === '3D'"),
-                    v_if=("interaction_mode_visibility",),
+                    v_if=("show_interaction_mode",),
                 )
 
             with (
@@ -99,7 +97,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-crop-free",
                         v_bind=("props",),
                         click=reset_camera_callback,
-                        v_if=("reset_camera_visibility",),
+                        v_if=("show_reset_camera",),
                     ),
                 )
 
@@ -115,7 +113,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-axis-x-arrow",
                         v_bind=("props",),
                         click=reset_to_positive_x,
-                        v_if=("reset_camera_x_visibility",),
+                        v_if=("show_reset_camera_x",),
                     ),
                 )
 
@@ -131,7 +129,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-axis-y-arrow",
                         v_bind=("props",),
                         click=reset_to_positive_y,
-                        v_if=("reset_camera_y_visibility",),
+                        v_if=("show_reset_camera_y",),
                     ),
                 )
 
@@ -147,7 +145,7 @@ class ResetCameraButtons(v3.VBtnGroup):
                         icon="mdi-axis-z-arrow",
                         v_bind=("props",),
                         click=reset_to_positive_z,
-                        v_if=("reset_camera_z_visibility",),
+                        v_if=("show_reset_camera_z",),
                     ),
                 )
 

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -29,7 +29,7 @@ class ResetCameraButtons(v3.VBtnGroup):
         self, style: str | None = None, classes: str | None = None, **kwargs
     ) -> None:
         if style is None:
-            style = "top: 0.5rem; left: 0.5rem"
+            style = "top: 0.5rem; left: 0.5rem; background-color: white;"
         if classes is None:
             classes = "position-absolute"
         super().__init__(

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -20,11 +20,9 @@ class ResetCameraButtons(v3.VBtnGroup):
     """
     A widget composed of 4 buttons to reset the camera of a view :
     - The first is used to reset the camera to see the entire object.
-    - The second places the camera at -x and look in the x direction.
-    - The third places the camera at -y and look in the y direction.
-    - The fourth places the camera at -z and look in the z direction.
-
-    By default, they will be placed at the top left of its parent component.
+    - The second places the camera at -x from the object and look in the x direction.
+    - The third places the camera at -y from the object and look in the y direction.
+    - The fourth places the camera at -z from the object and look in the z direction.
     """
 
     def __init__(
@@ -64,24 +62,22 @@ class ResetCameraButtons(v3.VBtnGroup):
             ),
             Button(
                 icon="mdi-axis-x-arrow",
-                tooltip="Reset Camera X",
+                tooltip="Set view direction to +X",
                 click_callback=reset_to_positive_x,
             ),
             Button(
                 icon="mdi-axis-y-arrow",
-                tooltip="Reset Camera Y",
+                tooltip="Set view direction to +Y",
                 click_callback=reset_to_positive_y,
             ),
             Button(
                 icon="mdi-axis-z-arrow",
-                tooltip="Reset Camera Z",
+                tooltip="Set view direction to +Z",
                 click_callback=reset_to_positive_z,
             ),
         ]
 
-        with (
-            self,
-        ):
+        with self:
             for button in buttons:
                 with (
                     v3.VTooltip(button.tooltip, location="bottom"),
@@ -91,10 +87,8 @@ class ResetCameraButtons(v3.VBtnGroup):
                         v_bind=("props",),
                         click=button.click_callback,
                         variant="text",
-                        # variant="outlined",
                         size="small",
                         classes="ma-0",
-                        style="background-color: white;",
                     ),
                 ):
                     v3.VIcon(button.icon)

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -14,6 +14,8 @@ class Button:
     icon: str
     tooltip: str
     click_callback: Callable
+    v_show: str = "true"
+    v_if: str = "true"
 
 
 class ResetCameraButtons(v3.VBtnGroup):
@@ -26,7 +28,15 @@ class ResetCameraButtons(v3.VBtnGroup):
     """
 
     def __init__(
-        self, style: str | None = None, classes: str | None = None, **kwargs
+        self,
+        style: str | None = None,
+        classes: str | None = None,
+        reset_camera: bool = True,
+        reset_camera_x: bool = True,
+        reset_camera_y: bool = True,
+        reset_camera_z: bool = True,
+        camera_style_toggle: bool = True,
+        **kwargs,
     ) -> None:
         if style is None:
             style = "top: 0.5rem; left: 0.5rem; background-color: white;"
@@ -38,9 +48,10 @@ class ResetCameraButtons(v3.VBtnGroup):
             **kwargs,
         )
 
-        def reset_camera() -> None:
+        self.state.setdefault("interaction_mode", "3D")
+
+        def reset_camera_callback() -> None:
             self.ctrl.view_reset_camera()
-            simple.Render()
 
         def reset_to_positive_x() -> None:
             self.view.ResetActiveCameraToPositiveX()
@@ -54,44 +65,78 @@ class ResetCameraButtons(v3.VBtnGroup):
             self.view.ResetActiveCameraToPositiveZ()
             self.ctrl.view_reset_camera()
 
+        def toggle_interaction_mode_2D() -> None:
+            self.view.InteractionMode = "2D"
+            self.state.interaction_mode = "2D"
+
+        def toggle_interaction_mode_3D() -> None:
+            self.view.InteractionMode = "3D"
+            self.state.interaction_mode = "3D"
+
         buttons = [
+            Button(
+                icon="mdi-video-2d",
+                tooltip="Change interaction mode",
+                click_callback=toggle_interaction_mode_3D,
+                v_show=("interaction_mode === '2D'"),
+                v_if="true" if camera_style_toggle else "false",
+            ),
+            Button(
+                icon="mdi-video-3d",
+                tooltip="Change interaction mode",
+                click_callback=toggle_interaction_mode_2D,
+                v_show=("interaction_mode === '3D'"),
+                v_if="true" if camera_style_toggle else "false",
+            ),
             Button(
                 icon="mdi-crop-free",
                 tooltip="Reset Camera",
-                click_callback=reset_camera,
+                click_callback=reset_camera_callback,
+                v_if="true" if reset_camera else "false",
             ),
             Button(
                 icon="mdi-axis-x-arrow",
                 tooltip="Set view direction to +X",
                 click_callback=reset_to_positive_x,
+                v_if="true" if reset_camera_x else "false",
             ),
             Button(
                 icon="mdi-axis-y-arrow",
                 tooltip="Set view direction to +Y",
                 click_callback=reset_to_positive_y,
+                v_if="true" if reset_camera_y else "false",
             ),
             Button(
                 icon="mdi-axis-z-arrow",
                 tooltip="Set view direction to +Z",
                 click_callback=reset_to_positive_z,
+                v_if="true" if reset_camera_z else "false",
             ),
         ]
 
         with self:
             for button in buttons:
-                with (
-                    v3.VTooltip(button.tooltip, location="bottom"),
-                    v3.Template(v_slot_activator=("{ props }",)),
+                if button.tooltip is None:
                     v3.VBtn(
-                        icon=True,
-                        v_bind=("props",),
+                        icon=button.icon,
                         click=button.click_callback,
-                        variant="text",
                         size="small",
-                        classes="ma-0",
-                    ),
-                ):
-                    v3.VIcon(button.icon)
+                        v_show=button.v_show,
+                        v_if=button.v_if,
+                    )
+                else:
+                    with (
+                        v3.VTooltip(button.tooltip, location="bottom"),
+                        v3.Template(v_slot_activator=("{ props }",)),
+                    ):
+                        v3.VBtn(
+                            icon=button.icon,
+                            v_bind=("props",),
+                            click=button.click_callback,
+                            size="small",
+                            v_show=button.v_show,
+                            v_if=button.v_if,
+                        )
 
     @property
     def view(self):

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -1,0 +1,104 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from paraview import simple
+from trame.widgets import vuetify3 as v3
+
+
+@dataclass
+class Button:
+    """
+    A minimal class to create a button.
+    """
+
+    icon: str
+    tooltip: str
+    click_callback: Callable
+
+
+class ResetCameraButtons(v3.VBtnGroup):
+    """
+    A widget composed of 4 buttons to reset the camera of a view :
+    - The first is used to reset the camera to see the entire object.
+    - The second places the camera at -x and look in the x direction.
+    - The third places the camera at -y and look in the y direction.
+    - The fourth places the camera at -z and look in the z direction.
+
+    By default, they will be placed at the top left of its parent component.
+    """
+
+    def __init__(
+        self, style: str | None = None, classes: str | None = None, **kwargs
+    ) -> None:
+        if style is None:
+            style = "top: 0.5rem; left: 0.5rem"
+        if classes is None:
+            classes = "position-absolute"
+        super().__init__(
+            style=style,
+            classes=classes,
+            **kwargs,
+        )
+
+        def reset_camera() -> None:
+            self.ctrl.view_reset_camera()
+            simple.Render()
+
+        def reset_to_positive_x() -> None:
+            simple.GetActiveView().ResetActiveCameraToPositiveX()
+            self.ctrl.view_reset_camera()
+
+        def reset_to_positive_y() -> None:
+            simple.GetActiveView().ResetActiveCameraToPositiveY()
+            self.ctrl.view_reset_camera()
+
+        def reset_to_positive_z() -> None:
+            simple.GetActiveView().ResetActiveCameraToPositiveZ()
+            self.ctrl.view_reset_camera()
+
+        buttons = [
+            Button(
+                icon="mdi-crop-free",
+                tooltip="Reset Camera",
+                click_callback=reset_camera,
+            ),
+            Button(
+                icon="mdi-axis-x-arrow",
+                tooltip="Reset Camera X",
+                click_callback=reset_to_positive_x,
+            ),
+            Button(
+                icon="mdi-axis-y-arrow",
+                tooltip="Reset Camera Y",
+                click_callback=reset_to_positive_y,
+            ),
+            Button(
+                icon="mdi-axis-z-arrow",
+                tooltip="Reset Camera Z",
+                click_callback=reset_to_positive_z,
+            ),
+        ]
+
+        with (
+            self,
+        ):
+            for button in buttons:
+                with (
+                    v3.VTooltip(button.tooltip, location="bottom"),
+                    v3.Template(v_slot_activator=("{ props }",)),
+                    v3.VBtn(
+                        icon=True,
+                        v_bind=("props",),
+                        click=button.click_callback,
+                        variant="text",
+                        # variant="outlined",
+                        size="small",
+                        classes="ma-0",
+                        style="background-color: white;",
+                    ),
+                ):
+                    v3.VIcon(button.icon)
+
+    @property
+    def view(self):
+        return simple.GetActiveView()

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -45,15 +45,15 @@ class ResetCameraButtons(v3.VBtnGroup):
             simple.Render()
 
         def reset_to_positive_x() -> None:
-            simple.GetActiveView().ResetActiveCameraToPositiveX()
+            self.view.ResetActiveCameraToPositiveX()
             self.ctrl.view_reset_camera()
 
         def reset_to_positive_y() -> None:
-            simple.GetActiveView().ResetActiveCameraToPositiveY()
+            self.view.ResetActiveCameraToPositiveY()
             self.ctrl.view_reset_camera()
 
         def reset_to_positive_z() -> None:
-            simple.GetActiveView().ResetActiveCameraToPositiveZ()
+            self.view.ResetActiveCameraToPositiveZ()
             self.ctrl.view_reset_camera()
 
         buttons = [

--- a/ptc/reset_camera_button.py
+++ b/ptc/reset_camera_button.py
@@ -31,11 +31,11 @@ class ResetCameraButtons(v3.VBtnGroup):
         self,
         style: str | None = None,
         classes: str | None = None,
-        reset_camera: bool = True,
-        reset_camera_x: bool = True,
-        reset_camera_y: bool = True,
-        reset_camera_z: bool = True,
-        camera_style_toggle: bool = True,
+        reset_camera_visibility: bool = True,
+        reset_camera_x_visibility: bool = True,
+        reset_camera_y_visibility: bool = True,
+        reset_camera_z_visibility: bool = True,
+        interaction_mode_visibility: bool = True,
         **kwargs,
     ) -> None:
         if style is None:
@@ -49,6 +49,13 @@ class ResetCameraButtons(v3.VBtnGroup):
         )
 
         self.state.setdefault("interaction_mode", "3D")
+        self.state.setdefault("reset_camera_visibility", reset_camera_visibility)
+        self.state.setdefault("reset_camera_x_visibility", reset_camera_x_visibility)
+        self.state.setdefault("reset_camera_y_visibility", reset_camera_y_visibility)
+        self.state.setdefault("reset_camera_z_visibility", reset_camera_z_visibility)
+        self.state.setdefault(
+            "interaction_mode_visibility", interaction_mode_visibility
+        )
 
         def reset_camera_callback() -> None:
             self.ctrl.view_reset_camera()
@@ -79,38 +86,38 @@ class ResetCameraButtons(v3.VBtnGroup):
                 tooltip="Change interaction mode",
                 click_callback=toggle_interaction_mode_3D,
                 v_show=("interaction_mode === '2D'"),
-                v_if="true" if camera_style_toggle else "false",
+                v_if=("interaction_mode_visibility",),
             ),
             Button(
                 icon="mdi-video-3d",
                 tooltip="Change interaction mode",
                 click_callback=toggle_interaction_mode_2D,
                 v_show=("interaction_mode === '3D'"),
-                v_if="true" if camera_style_toggle else "false",
+                v_if=("interaction_mode_visibility",),
             ),
             Button(
                 icon="mdi-crop-free",
                 tooltip="Reset Camera",
                 click_callback=reset_camera_callback,
-                v_if="true" if reset_camera else "false",
+                v_if=("reset_camera_visibility",),
             ),
             Button(
                 icon="mdi-axis-x-arrow",
                 tooltip="Set view direction to +X",
                 click_callback=reset_to_positive_x,
-                v_if="true" if reset_camera_x else "false",
+                v_if=("reset_camera_x_visibility",),
             ),
             Button(
                 icon="mdi-axis-y-arrow",
                 tooltip="Set view direction to +Y",
                 click_callback=reset_to_positive_y,
-                v_if="true" if reset_camera_y else "false",
+                v_if=("reset_camera_y_visibility",),
             ),
             Button(
                 icon="mdi-axis-z-arrow",
                 tooltip="Set view direction to +Z",
                 click_callback=reset_to_positive_z,
-                v_if="true" if reset_camera_z else "false",
+                v_if=("reset_camera_z_visibility",),
             ),
         ]
 


### PR DESCRIPTION
This merge request aims to add a small widget that adds buttons to control the camera.
Those buttons act just like ParaView's one, which reset the camera and make it look in a certain direction along an axis.
I have added an example to illustrate how to use them in an app that uses ParaView.

I think they can be added to the Viewer class to replace the button which resets the camera.

By default, they will look like this : 
<img width="181" height="60" alt="reset-camera" src="https://github.com/user-attachments/assets/6176c8d3-bdea-4425-b4a7-68bea687169e" />

But the appearance can be customized, just like the VButtonGroup of Vuetify.

This widget does not create/add functions to the controller and only needs a `view_reset_camera` function to be defined.